### PR TITLE
Very simple example page using grunt gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 bower_components
 reports
+.grunt
 dist/_bower.js

--- a/grunt/gh-pages.yaml
+++ b/grunt/gh-pages.yaml
@@ -1,0 +1,7 @@
+options:
+  base: '.'
+  branch: 'gh-pages'
+src:
+  - 'dist/*.*'
+  - 'example/*.*'
+  - 'bower_components/**/*.*'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "grunt-mocha": "~0.4.1",
     "grunt-notify": "~0.2.13",
     "grunt-shell": "~0.4.0",
-    "load-grunt-config":"~0.6.0"
+    "load-grunt-config": "~0.6.0"
+  },
+  "dependencies": {
+    "grunt-gh-pages": "~0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "grunt-mocha": "~0.4.1",
     "grunt-notify": "~0.2.13",
     "grunt-shell": "~0.4.0",
-    "load-grunt-config": "~0.6.0"
+    "load-grunt-config": "~0.6.0",
+    "grunt-gh-pages": "~0.9.0"
   },
   "dependencies": {
-    "grunt-gh-pages": "~0.9.0"
   }
 }


### PR DESCRIPTION
Now `grunt gh-pages` will create a sample page at `http://{{username}}.github.io/floating-label/example/`.
